### PR TITLE
Opnames

### DIFF
--- a/model.py
+++ b/model.py
@@ -117,17 +117,18 @@ class Model():
     
     # I could put all of these in a single tensor for reading out, but this is more human readable
     data_out_pi = tf.identity(o_pi, "data_out_pi");
-    data_out_mu1 = tf.identity(o_pi, "data_out_mu1");
-    data_out_mu2 = tf.identity(o_pi, "data_out_mu2");
-    data_out_sigma1 = tf.identity(o_pi, "data_out_sigma1");
-    data_out_sigma2 = tf.identity(o_pi, "data_out_sigma2");
-    data_out_corr = tf.identity(o_pi, "data_out_corr");
-    data_out_eos = tf.identity(o_pi, "data_out_eos");
+    data_out_mu1 = tf.identity(o_mu1, "data_out_mu1");
+    data_out_mu2 = tf.identity(o_mu2, "data_out_mu2");
+    data_out_sigma1 = tf.identity(o_sigma1, "data_out_sigma1");
+    data_out_sigma2 = tf.identity(o_sigma2, "data_out_sigma2");
+    data_out_corr = tf.identity(o_corr, "data_out_corr");
+    data_out_eos = tf.identity(o_eos, "data_out_eos");
                               
-    # sticking them all in one op anyway, makes it easier for freezing the graph later                          
+    # sticking them all (except eos) in one op anyway, makes it easier for freezing the graph later                          
     # IMPORTANT, this needs to stack the named ops above (data_out_XXX), not the prev ops (o_XXX)
     # otherwise when I freeze the graph up to this point, the named versions will be cut
-    data_out = tf.stack([data_out_pi, data_out_mu1, data_out_mu2, data_out_sigma1, data_out_sigma2, data_out_corr, data_out_eos], name="data_out")                     
+    # eos is diff size to others, so excluding that
+    data_out_mdn = tf.identity([data_out_pi, data_out_mu1, data_out_mu2, data_out_sigma1, data_out_sigma2, data_out_corr], name="data_out_mdn")
 
     self.pi = o_pi
     self.mu1 = o_mu1

--- a/model.py
+++ b/model.py
@@ -124,6 +124,8 @@ class Model():
 
     lossfunc = get_lossfunc(o_pi, o_mu1, o_mu2, o_sigma1, o_sigma2, o_corr, o_eos, x1_data, x2_data, eos_data)
     self.cost = lossfunc / (args.batch_size * args.seq_length)
+    
+    tf.summary.scalar('loss', self.cost) 
 
     self.lr = tf.Variable(0.0, trainable=False)
     tvars = tf.trainable_variables()

--- a/model.py
+++ b/model.py
@@ -31,9 +31,10 @@ class Model():
 
     self.cell = cell
 
-    self.input_data = tf.placeholder(dtype=tf.float32, shape=[None, args.seq_length, 3])
-    self.target_data = tf.placeholder(dtype=tf.float32, shape=[None, args.seq_length, 3])
-    self.initial_state = cell.zero_state(batch_size=args.batch_size, dtype=tf.float32)
+    self.input_data = tf.placeholder(dtype=tf.float32, shape=[None, args.seq_length, 3], name='data_in')
+    self.target_data = tf.placeholder(dtype=tf.float32, shape=[None, args.seq_length, 3], name='targets')
+    zero_state = cell.zero_state(batch_size=args.batch_size, dtype=tf.float32)
+    self.state_in = tf.identity(zero_state, name='state_in')
 
     self.num_mixture = args.num_mixture
     NOUT = 1 + self.num_mixture * 6 # end_of_stroke + prob + 2*(mu + sig) + corr
@@ -45,10 +46,10 @@ class Model():
     inputs = tf.split(axis=1, num_or_size_splits=args.seq_length, value=self.input_data)
     inputs = [tf.squeeze(input_, [1]) for input_ in inputs]
 
-    outputs, last_state = tf.contrib.legacy_seq2seq.rnn_decoder(inputs, self.initial_state, cell, loop_function=None, scope='rnnlm')
+    outputs, state_out = tf.contrib.legacy_seq2seq.rnn_decoder(inputs, self.state_in, cell, loop_function=None, scope='rnnlm')
     output = tf.reshape(tf.concat(axis=1, values=outputs), [-1, args.rnn_size])
     output = tf.nn.xw_plus_b(output, output_w, output_b)
-    self.final_state = last_state
+    self.state_out = tf.identity(state_out, name='state_out')
 
     # reshape target data so that it is compatible with prediction shape
     flat_target_data = tf.reshape(self.target_data,[-1, 3])
@@ -113,6 +114,20 @@ class Model():
       return [z_pi, z_mu1, z_mu2, z_sigma1, z_sigma2, z_corr, z_eos]
 
     [o_pi, o_mu1, o_mu2, o_sigma1, o_sigma2, o_corr, o_eos] = get_mixture_coef(output)
+    
+    # I could put all of these in a single tensor for reading out, but this is more human readable
+    data_out_pi = tf.identity(o_pi, "data_out_pi");
+    data_out_mu1 = tf.identity(o_pi, "data_out_mu1");
+    data_out_mu2 = tf.identity(o_pi, "data_out_mu2");
+    data_out_sigma1 = tf.identity(o_pi, "data_out_sigma1");
+    data_out_sigma2 = tf.identity(o_pi, "data_out_sigma2");
+    data_out_corr = tf.identity(o_pi, "data_out_corr");
+    data_out_eos = tf.identity(o_pi, "data_out_eos");
+                              
+    # sticking them all in one op anyway, makes it easier for freezing the graph later                          
+    # IMPORTANT, this needs to stack the named ops above (data_out_XXX), not the prev ops (o_XXX)
+    # otherwise when I freeze the graph up to this point, the named versions will be cut
+    data_out = tf.stack([data_out_pi, data_out_mu1, data_out_mu2, data_out_sigma1, data_out_sigma2, data_out_corr, data_out_eos], name="data_out")                     
 
     self.pi = o_pi
     self.mu1 = o_mu1
@@ -161,9 +176,9 @@ class Model():
 
     for i in range(num):
 
-      feed = {self.input_data: prev_x, self.initial_state:prev_state}
+      feed = {self.input_data: prev_x, self.state_in:prev_state}
 
-      [o_pi, o_mu1, o_mu2, o_sigma1, o_sigma2, o_corr, o_eos, next_state] = sess.run([self.pi, self.mu1, self.mu2, self.sigma1, self.sigma2, self.corr, self.eos, self.final_state],feed)
+      [o_pi, o_mu1, o_mu2, o_sigma1, o_sigma2, o_corr, o_eos, next_state] = sess.run([self.pi, self.mu1, self.mu2, self.sigma1, self.sigma2, self.corr, self.eos, self.state_out],feed)
 
       idx = get_pi_idx(random.random(), o_pi[0])
 

--- a/model.py
+++ b/model.py
@@ -11,23 +11,23 @@ class Model():
       args.seq_length = 1
 
     if args.model == 'rnn':
-      cell_fn = tf.nn.rnn_cell.BasicRNNCell
+      cell_fn = tf.contrib.rnn.BasicRNNCell
     elif args.model == 'gru':
-      cell_fn = tf.nn.rnn_cell.GRUCell
+      cell_fn = tf.contrib.rnn.GRUCell
     elif args.model == 'lstm':
-      cell_fn = tf.nn.rnn_cell.BasicLSTMCell
+      cell_fn = tf.contrib.rnn.BasicLSTMCell
     else:
       raise Exception("model type not supported: {}".format(args.model))
 
     cell = cell_fn(args.rnn_size, state_is_tuple=False)
 
-    cell = tf.nn.rnn_cell.MultiRNNCell(
+    cell = tf.contrib.rnn.MultiRNNCell(
             [cell] * args.num_layers,
             state_is_tuple=False
         )
 
     if (infer == False and args.keep_prob < 1): # training mode
-      cell = tf.nn.rnn_cell.DropoutWrapper(cell, output_keep_prob = args.keep_prob)
+      cell = tf.contrib.rnn.DropoutWrapper(cell, output_keep_prob = args.keep_prob)
 
     self.cell = cell
 
@@ -42,17 +42,17 @@ class Model():
       output_w = tf.get_variable("output_w", [args.rnn_size, NOUT])
       output_b = tf.get_variable("output_b", [NOUT])
 
-    inputs = tf.split(1, args.seq_length, self.input_data)
+    inputs = tf.split(axis=1, num_or_size_splits=args.seq_length, value=self.input_data)
     inputs = [tf.squeeze(input_, [1]) for input_ in inputs]
 
-    outputs, last_state = tf.nn.seq2seq.rnn_decoder(inputs, self.initial_state, cell, loop_function=None, scope='rnnlm')
-    output = tf.reshape(tf.concat(1, outputs), [-1, args.rnn_size])
+    outputs, last_state = tf.contrib.legacy_seq2seq.rnn_decoder(inputs, self.initial_state, cell, loop_function=None, scope='rnnlm')
+    output = tf.reshape(tf.concat(axis=1, values=outputs), [-1, args.rnn_size])
     output = tf.nn.xw_plus_b(output, output_w, output_b)
     self.final_state = last_state
 
     # reshape target data so that it is compatible with prediction shape
     flat_target_data = tf.reshape(self.target_data,[-1, 3])
-    [x1_data, x2_data, eos_data] = tf.split(1, 3, flat_target_data)
+    [x1_data, x2_data, eos_data] = tf.split(axis=1, num_or_size_splits=3, value=flat_target_data)
 
     # long method:
     #flat_target_data = tf.split(1, args.seq_length, self.target_data)
@@ -61,13 +61,13 @@ class Model():
 
     def tf_2d_normal(x1, x2, mu1, mu2, s1, s2, rho):
       # eq # 24 and 25 of http://arxiv.org/abs/1308.0850
-      norm1 = tf.sub(x1, mu1)
-      norm2 = tf.sub(x2, mu2)
-      s1s2 = tf.mul(s1, s2)
-      z = tf.square(tf.div(norm1, s1))+tf.square(tf.div(norm2, s2))-2*tf.div(tf.mul(rho, tf.mul(norm1, norm2)), s1s2)
+      norm1 = tf.subtract(x1, mu1)
+      norm2 = tf.subtract(x2, mu2)
+      s1s2 = tf.multiply(s1, s2)
+      z = tf.square(tf.div(norm1, s1))+tf.square(tf.div(norm2, s2))-2*tf.div(tf.multiply(rho, tf.multiply(norm1, norm2)), s1s2)
       negRho = 1-tf.square(rho)
       result = tf.exp(tf.div(-z,2*negRho))
-      denom = 2*np.pi*tf.mul(s1s2, tf.sqrt(negRho))
+      denom = 2*np.pi*tf.multiply(s1s2, tf.sqrt(negRho))
       result = tf.div(result, denom)
       return result
 
@@ -75,11 +75,11 @@ class Model():
       result0 = tf_2d_normal(x1_data, x2_data, z_mu1, z_mu2, z_sigma1, z_sigma2, z_corr)
       # implementing eq # 26 of http://arxiv.org/abs/1308.0850
       epsilon = 1e-20
-      result1 = tf.mul(result0, z_pi)
+      result1 = tf.multiply(result0, z_pi)
       result1 = tf.reduce_sum(result1, 1, keep_dims=True)
       result1 = -tf.log(tf.maximum(result1, 1e-20)) # at the beginning, some errors are exactly zero.
 
-      result2 = tf.mul(z_eos, eos_data) + tf.mul(1-z_eos, 1-eos_data)
+      result2 = tf.multiply(z_eos, eos_data) + tf.multiply(1-z_eos, 1-eos_data)
       result2 = -tf.log(result2)
 
       result = result1 + result2
@@ -91,7 +91,7 @@ class Model():
       # ie, eq 18 -> 23 of http://arxiv.org/abs/1308.0850
       z = output
       z_eos = z[:, 0:1]
-      z_pi, z_mu1, z_mu2, z_sigma1, z_sigma2, z_corr = tf.split(1, 6, z[:, 1:])
+      z_pi, z_mu1, z_mu2, z_sigma1, z_sigma2, z_corr = tf.split(axis=1, num_or_size_splits=6, value=z[:, 1:])
 
       # process output z's into MDN paramters
 
@@ -100,10 +100,10 @@ class Model():
 
       # softmax all the pi's:
       max_pi = tf.reduce_max(z_pi, 1, keep_dims=True)
-      z_pi = tf.sub(z_pi, max_pi)
+      z_pi = tf.subtract(z_pi, max_pi)
       z_pi = tf.exp(z_pi)
       normalize_pi = tf.reciprocal(tf.reduce_sum(z_pi, 1, keep_dims=True))
-      z_pi = tf.mul(normalize_pi, z_pi)
+      z_pi = tf.multiply(normalize_pi, z_pi)
 
       # exponentiate the sigmas and also make corr between -1 and 1.
       z_sigma1 = tf.exp(z_sigma1)

--- a/sample.py
+++ b/sample.py
@@ -25,6 +25,9 @@ parser.add_argument('--scale_factor', type=int, default=10,
                    help='factor to scale down by for svg output.  smaller means bigger output')
 parser.add_argument('--model_dir', type=str, default='save',
                    help='directory to save model to')
+parser.add_argument('--freeze_graph', dest='freeze_graph', action='store_true',
+                   help='if true, freeze (replace variables with consts), prune (for inference) and save graph')
+	
 sample_args = parser.parse_args()
 
 with open(os.path.join(sample_args.model_dir, 'config.pkl'), 'rb') as f:
@@ -48,6 +51,19 @@ def sample_stroke():
   draw_strokes_eos_weighted(strokes, params, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.eos_pdf.svg')
   draw_strokes_pdf(strokes, params, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.pdf.svg')
   return [strokes, params]
+
+
+def freeze_and_save_graph(sess, folder, out_nodes, as_text=False):
+    ## save graph definition
+    graph_raw = sess.graph_def
+    graph_frz = tf.graph_util.convert_variables_to_constants(sess, graph_raw, out_nodes)
+    ext = '.txt' if as_text else '.pb'
+    #tf.train.write_graph(graph_raw, folder, 'graph_raw'+ext, as_text=as_text)
+    tf.train.write_graph(graph_frz, folder, 'graph_frz'+ext, as_text=as_text)
+    
+
+if(sample_args.freeze_graph):
+    freeze_and_save_graph(sess, sample_args.model_dir, ['data_out', 'state_out'], False)
 
 [strokes, params] = sample_stroke()
 

--- a/sample.py
+++ b/sample.py
@@ -63,7 +63,7 @@ def freeze_and_save_graph(sess, folder, out_nodes, as_text=False):
     
 
 if(sample_args.freeze_graph):
-    freeze_and_save_graph(sess, sample_args.model_dir, ['data_out', 'state_out'], False)
+    freeze_and_save_graph(sess, sample_args.model_dir, ['data_out_mdn', 'data_out_eos', 'state_out'], False)
 
 [strokes, params] = sample_stroke()
 

--- a/sample_frozen.py
+++ b/sample_frozen.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Feb 23 20:25:16 2017
+
+@author: memo
+
+demonstrates inference with frozen graph def
+same as sample.py, but:
+- instead of loading model + checkpoint, loads frozen graph
+- instead of calling model.sample() function, uses own sample() function with named ops
+"""
+
+import numpy as np
+import tensorflow as tf
+
+import time
+import os
+import pickle
+import argparse
+
+from utils import *
+from model import Model
+import random
+
+
+import svgwrite
+from IPython.display import SVG, display
+
+# main code (not in a main function since I want to run this script in IPython as well).
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--filename', type=str, default='sample',
+                   help='filename of .svg file to output, without .svg')
+parser.add_argument('--sample_length', type=int, default=800,
+                   help='number of strokes to sample')
+parser.add_argument('--scale_factor', type=int, default=10,
+                   help='factor to scale down by for svg output.  smaller means bigger output')
+parser.add_argument('--model_dir', type=str, default='save',
+                   help='directory to save model to')
+sample_args = parser.parse_args()
+
+sess = tf.InteractiveSession()
+
+# load frozen graph
+from tensorflow.python.platform import gfile
+with gfile.FastGFile(os.path.join(sample_args.model_dir, 'graph_frz.pb'),'rb') as f:
+    graph_def = tf.GraphDef()
+    graph_def.ParseFromString(f.read())
+    sess.graph.as_default()
+    tf.import_graph_def(graph_def, name='')        
+       
+
+
+def sample_stroke():
+  # don't  call model.sample(), instead call sample() function defined below
+  [strokes, params] = sample(sess, sample_args.sample_length)
+  draw_strokes(strokes, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.normal.svg')
+  draw_strokes_random_color(strokes, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.color.svg')
+  draw_strokes_random_color(strokes, factor=sample_args.scale_factor, per_stroke_mode = False, svg_filename = sample_args.filename+'.multi_color.svg')
+  draw_strokes_eos_weighted(strokes, params, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.eos_pdf.svg')
+  draw_strokes_pdf(strokes, params, factor=sample_args.scale_factor, svg_filename = sample_args.filename+'.pdf.svg')
+  return [strokes, params]
+
+
+# copied straight from model.sample, but replaced all referenes to 'self' with named ops
+def sample(sess, num=1200):
+  data_in = 'data_in:0'
+  data_out_pi = 'data_out_pi:0'
+  data_out_mu1 = 'data_out_mu1:0'
+  data_out_mu2 = 'data_out_mu2:0'
+  data_out_sigma1 = 'data_out_sigma1:0'
+  data_out_sigma2 = 'data_out_sigma2:0'
+  data_out_corr = 'data_out_corr:0'
+  data_out_eos = 'data_out_eos:0'
+  state_in = 'state_in:0'
+  state_out = 'state_out:0'
+
+  def get_pi_idx(x, pdf):
+    N = pdf.size
+    accumulate = 0
+    for i in range(0, N):
+      accumulate += pdf[i]
+      if (accumulate >= x):
+        return i
+    print('error with sampling ensemble')
+    return -1
+
+  def sample_gaussian_2d(mu1, mu2, s1, s2, rho):
+    mean = [mu1, mu2]
+    cov = [[s1*s1, rho*s1*s2], [rho*s1*s2, s2*s2]]
+    x = np.random.multivariate_normal(mean, cov, 1)
+    return x[0][0], x[0][1]
+
+  prev_x = np.zeros((1, 1, 3), dtype=np.float32)
+  prev_x[0, 0, 2] = 1 # initially, we want to see beginning of new stroke
+  prev_state = sess.run(state_in)
+
+  strokes = np.zeros((num, 3), dtype=np.float32)
+  mixture_params = []
+
+  for i in range(num):
+
+    feed = {data_in: prev_x, state_in:prev_state}
+
+    [o_pi, o_mu1, o_mu2, o_sigma1, o_sigma2, o_corr, o_eos, next_state] = sess.run([data_out_pi, data_out_mu1, data_out_mu2, data_out_sigma1, data_out_sigma2, data_out_corr, data_out_eos, state_out],feed)
+
+    idx = get_pi_idx(random.random(), o_pi[0])
+
+    eos = 1 if random.random() < o_eos[0][0] else 0
+
+    next_x1, next_x2 = sample_gaussian_2d(o_mu1[0][idx], o_mu2[0][idx], o_sigma1[0][idx], o_sigma2[0][idx], o_corr[0][idx])
+
+    strokes[i,:] = [next_x1, next_x2, eos]
+
+    params = [o_pi[0], o_mu1[0], o_mu2[0], o_sigma1[0], o_sigma2[0], o_corr[0], o_eos[0]]
+    mixture_params.append(params)
+
+    prev_x = np.zeros((1, 1, 3), dtype=np.float32)
+    prev_x[0][0] = np.array([next_x1, next_x2, eos], dtype=np.float32)
+    prev_state = next_state
+
+  strokes[:,0:2] *= 20 #self.args.data_scale # TODO: fix mega hack hardcoding the scale
+  return strokes, mixture_params
+
+
+# check output
+[strokes, params] = sample_stroke()
+
+

--- a/train.py
+++ b/train.py
@@ -63,13 +63,13 @@ def train(args):
             sess.run(tf.assign(model.lr, args.learning_rate * (args.decay_rate ** e)))
             data_loader.reset_batch_pointer()
             v_x, v_y = data_loader.validation_data()
-            valid_feed = {model.input_data: v_x, model.target_data: v_y, model.initial_state: model.initial_state.eval()}
-            state = model.initial_state.eval()
+            valid_feed = {model.input_data: v_x, model.target_data: v_y, model.state_in: model.state_in.eval()}
+            state = model.state_in.eval()
             for b in range(data_loader.num_batches):
                 start = time.time()
                 x, y = data_loader.next_batch()
-                feed = {model.input_data: x, model.target_data: y, model.initial_state: state}
-                summary, train_loss, state, _ = sess.run([merged_summaries, model.cost, model.final_state, model.train_op], feed) 
+                feed = {model.input_data: x, model.target_data: y, model.state_in: state}
+                summary, train_loss, state, _ = sess.run([merged_summaries, model.cost, model.state_out, model.train_op], feed) 
                 summary_writer.add_summary(summary, e * data_loader.num_batches + b)                 
                 valid_loss, = sess.run([model.cost], valid_feed)
                 end = time.time()

--- a/train.py
+++ b/train.py
@@ -54,8 +54,8 @@ def train(args):
     model = Model(args)
 
     with tf.Session() as sess:
-        tf.initialize_all_variables().run()
-        saver = tf.train.Saver(tf.all_variables())
+        tf.global_variables_initializer().run()
+        saver = tf.train.Saver(tf.global_variables())
         for e in range(args.num_epochs):
             sess.run(tf.assign(model.lr, args.learning_rate * (args.decay_rate ** e)))
             data_loader.reset_batch_pointer()

--- a/train.py
+++ b/train.py
@@ -54,6 +54,9 @@ def train(args):
     model = Model(args)
 
     with tf.Session() as sess:
+        merged_summaries = tf.summary.merge_all() 
+        summary_writer = tf.summary.FileWriter(os.path.join(args.model_dir, 'log'), sess.graph) 
+        
         tf.global_variables_initializer().run()
         saver = tf.train.Saver(tf.global_variables())
         for e in range(args.num_epochs):
@@ -66,7 +69,8 @@ def train(args):
                 start = time.time()
                 x, y = data_loader.next_batch()
                 feed = {model.input_data: x, model.target_data: y, model.initial_state: state}
-                train_loss, state, _ = sess.run([model.cost, model.final_state, model.train_op], feed)
+                summary, train_loss, state, _ = sess.run([merged_summaries, model.cost, model.final_state, model.train_op], feed) 
+                summary_writer.add_summary(summary, e * data_loader.num_batches + b)                 
                 valid_loss, = sess.run([model.cost], valid_feed)
                 end = time.time()
                 print(


### PR DESCRIPTION
Hey, after the TF1 pull request, merge this if you want. It structures the graph so that the main ops needed for inference can be accessed by name (data_in, state_in, all the data_out for all mdn params, eos, state_out).

If you look at sample_frozen.py you'll see what I mean. I also have it working in openframeworks too. Will post that example separately. 

Note if you look at the diff before merging TF1, you'll also see a bunch of tensorflow 1 compatibility changes. 