### PR TITLE
Fix number of layers when constructing MultiRNNCell

### DIFF
--- a/model.py
+++ b/model.py
@@ -23,7 +23,7 @@ class Model():
       return cell_fn(args.rnn_size, state_is_tuple=False)
 
     cell = tf.contrib.rnn.MultiRNNCell(
-        [get_cell() for _ in range(args.rnn_size)])
+        [get_cell() for _ in range(args.num_layers)])
 
     if (infer == False and args.keep_prob < 1): # training mode
       cell = tf.contrib.rnn.DropoutWrapper(cell, output_keep_prob = args.keep_prob)


### PR DESCRIPTION
Simple fix! 

Without this, the code attempts to construct a net that is `rnn_size` deep -- as deep as it is wide. 

Tested with tensorflow v1.5 on a MBP. 